### PR TITLE
Fixes regression on crawlers endpoint caused by Typescript configuration

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "lib": ["es6"],                           /* Specify library files to be included in the compilation. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */


### PR DESCRIPTION
The Typescript backend configuration caused a regression on the edit crawlers endpoint when trying to spread a Set in order to get unique values. 

It was set to an ES5 target and would have needed a polyfill for that operation, switching to ES6 solved the bug (and doesn't cause a compatibilty issue as it is on server-side code).