### PR TITLE
#45 Real-time updates for new search results

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,2 +1,2 @@
 REACT_APP_API_URL=http://localhost:3001/api
-SOCKET_API_URL=http://localhost:3001
+REACT_APP_SOCKET_API_URL=http://localhost:3001

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,1 +1,2 @@
 REACT_APP_API_URL=http://localhost:3001/api
+SOCKET_API_URL=http://localhost:3001

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2081,6 +2081,11 @@
         }
       }
     },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+    },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -2280,6 +2285,11 @@
         "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1"
       }
+    },
+    "arraybuffer.slice": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
     "arrify": {
       "version": "1.0.1",
@@ -2863,6 +2873,11 @@
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2923,6 +2938,11 @@
         }
       }
     },
+    "base64-arraybuffer": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -2939,6 +2959,14 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "better-assert": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "requires": {
+        "callsite": "1.0.0"
       }
     },
     "big.js": {
@@ -2959,6 +2987,11 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "blob": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
     "bluebird": {
       "version": "3.7.2",
@@ -3297,6 +3330,11 @@
       "requires": {
         "caller-callsite": "^2.0.0"
       }
+    },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
     },
     "callsites": {
       "version": "2.0.0",
@@ -3644,10 +3682,20 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
+    "component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+    },
+    "component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
     },
     "compose-function": {
       "version": "3.0.3",
@@ -4741,6 +4789,46 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "engine.io-client": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.3.tgz",
+      "integrity": "sha512-0NGY+9hioejTEJCaSJZfWZLk4FPI9dN+1H1C4+wj2iuFba47UgZbJzfWs4aNFajnX/qAaYKbe2lLTfEEWzCmcw==",
+      "requires": {
+        "component-emitter": "~1.3.0",
+        "component-inherit": "0.0.3",
+        "debug": "~4.1.0",
+        "engine.io-parser": "~2.2.0",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "~6.1.0",
+        "xmlhttprequest-ssl": "~1.5.4",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+          "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
+      "integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "~0.0.7",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.5",
+        "has-binary2": "~1.0.2"
       }
     },
     "enhanced-resolve": {
@@ -6337,6 +6425,26 @@
         }
       }
     },
+    "has-binary2": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+      "requires": {
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+        }
+      }
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -6743,6 +6851,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "infer-owner": {
       "version": "1.0.4",
@@ -8905,6 +9018,11 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-component": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -9287,6 +9405,22 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+    },
+    "parseqs": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseuri": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
     },
     "parseurl": {
       "version": "1.3.3",
@@ -12302,6 +12436,69 @@
         "kind-of": "^3.2.0"
       }
     },
+    "socket.io-client": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
+      "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
+      "requires": {
+        "backo2": "1.0.2",
+        "base64-arraybuffer": "0.1.5",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "~4.1.0",
+        "engine.io-client": "~3.4.0",
+        "has-binary2": "~1.0.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "~3.3.0",
+        "to-array": "0.1.4"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+      "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "debug": "~3.1.0",
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "sockjs": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
@@ -13098,6 +13295,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+    },
+    "to-array": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -14474,6 +14676,11 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+    },
     "xregexp": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.3.0.tgz",
@@ -14549,6 +14756,11 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
     }
   }
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3898,6 +3898,18 @@
         "parse-json": "^4.0.0"
       }
     },
+    "cpr": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cpr/-/cpr-3.0.1.tgz",
+      "integrity": "sha1-uaVQOLfNgaNcF7l2GJW9hJau8eU=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.5",
+        "minimist": "^1.2.0",
+        "mkdirp": "~0.5.1",
+        "rimraf": "^2.5.4"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "copy": "cpr build ../server/src/public --delete-first --overwrite",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint ./src/"
@@ -39,6 +40,7 @@
     ]
   },
   "devDependencies": {
+    "cpr": "^3.0.1",
     "eslint": "^6.6.0",
     "eslint-config-airbnb": "^18.2.0",
     "eslint-plugin-import": "^2.22.0",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "react-infinite-scroll-component": "^5.0.5",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.1",
+    "socket.io-client": "^2.3.0",
     "use-debounce": "^3.4.3"
   },
   "scripts": {

--- a/client/src/components/Mention/MentionList.jsx
+++ b/client/src/components/Mention/MentionList.jsx
@@ -1,13 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import socketIOClient from 'socket.io-client';
 
 import { Fade, CircularProgress } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import InfiniteScroll from 'react-infinite-scroll-component';
 
 import MentionItem from './MentionItem';
-const ENDPOINT = 'http://localhost:3001';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -36,17 +34,6 @@ const MentionList = ({
 
   const [currentPage, setCurrentPage] = useState(1);
   const [displayedMentions, setDisplayedMentions] = useState();
-  const [lastResponse, setLastResponse] = useState('');
-
-  useEffect(() => {
-    const socket = socketIOClient(ENDPOINT);
-    socket.on('test', (data) => {
-      setLastResponse(data);
-    });
-
-    // Clean up the socket
-    return () => socket.disconnect();
-  }, []);
 
   useEffect(() => {
     setDisplayedMentions(mentions.slice(0, currentPage * pageSize));
@@ -82,7 +69,6 @@ const MentionList = ({
     )
     : (
       <div className={classes.loadingWrapper}>
-        <p>{lastResponse}</p>
         { isLoading
           ? <CircularProgress className={classes.loading} />
           : <div>No mentions were found for your current search criteria.</div>}

--- a/client/src/components/Mention/MentionList.jsx
+++ b/client/src/components/Mention/MentionList.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import socketIOClient from 'socket.io-client';
 
 import { Fade, CircularProgress } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import InfiniteScroll from 'react-infinite-scroll-component';
 
 import MentionItem from './MentionItem';
+const ENDPOINT = 'http://localhost:3001';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -34,6 +36,17 @@ const MentionList = ({
 
   const [currentPage, setCurrentPage] = useState(1);
   const [displayedMentions, setDisplayedMentions] = useState();
+  const [lastResponse, setLastResponse] = useState('');
+
+  useEffect(() => {
+    const socket = socketIOClient(ENDPOINT);
+    socket.on('test', (data) => {
+      setLastResponse(data);
+    });
+
+    // Clean up the socket
+    return () => socket.disconnect();
+  }, []);
 
   useEffect(() => {
     setDisplayedMentions(mentions.slice(0, currentPage * pageSize));
@@ -69,6 +82,7 @@ const MentionList = ({
     )
     : (
       <div className={classes.loadingWrapper}>
+        <p>{lastResponse}</p>
         { isLoading
           ? <CircularProgress className={classes.loading} />
           : <div>No mentions were found for your current search criteria.</div>}

--- a/client/src/pages/DashboardPage.jsx
+++ b/client/src/pages/DashboardPage.jsx
@@ -2,12 +2,17 @@ import React, { useContext, useEffect, useState } from 'react';
 import { useDebounce } from 'use-debounce';
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
 import { makeStyles } from '@material-ui/core/styles';
+import socketIOClient from 'socket.io-client';
 
 import { SearchContext } from '../contexts/Search';
 import SearchApi from '../utils/api/SearchApi';
 
 import MentionList from '../components/Mention/MentionList';
 import { UserContext } from '../contexts/User';
+
+import consts from '../utils/consts';
+
+const { SOCKET_URL } = consts.env;
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -44,6 +49,18 @@ const DashboardPage = () => {
           setisLoading(false);
         });
     }
+
+    const socket = socketIOClient(SOCKET_URL, {
+      query: `type=${sort}&term=${debouncedSearch}`,
+    });
+
+    socket.on('mention', (data) => {
+      // Spread operator, wrapper function (recommended)
+      setMentions((previous) => [data, ...previous]);
+    });
+
+    // Clean up the socket
+    return () => socket.disconnect();
   }, [debouncedSearch, sort, user]);
 
   const handleSortChange = (event, newSort) => {

--- a/client/src/utils/api/AuthApi.js
+++ b/client/src/utils/api/AuthApi.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
+import consts from '../consts';
 
-const API_URL = process.env.REACT_APP_API_URL;
+const { API_URL } = consts.env;
 
 export default class AuthApi {
   static login(username, password) {

--- a/client/src/utils/api/SearchApi.js
+++ b/client/src/utils/api/SearchApi.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
+import consts from '../consts';
 
-const API_URL = process.env.REACT_APP_API_URL;
+const { API_URL } = consts.env;
 
 export default class SearchApi {
   static search(type, term) {

--- a/client/src/utils/consts.js
+++ b/client/src/utils/consts.js
@@ -1,4 +1,7 @@
 export default {
+  env: {
+    API_URL: process.env.REACT_APP_API_URL,
+  },
   CRAWLERS: [
     { name: 'twitter', label: 'Twitter', logo: require('../assets/img/crawlers/twitter.svg') },
     { name: 'reddit', label: 'Reddit', logo: require('../assets/img/crawlers/reddit.svg') },

--- a/client/src/utils/consts.js
+++ b/client/src/utils/consts.js
@@ -1,7 +1,7 @@
 export default {
   env: {
     API_URL: process.env.REACT_APP_API_URL,
-    SOCKET_URL: process.env.SOCKET_API_URL,
+    SOCKET_URL: process.env.REACT_APP_SOCKET_API_URL,
   },
   CRAWLERS: [
     { name: 'twitter', label: 'Twitter', logo: require('../assets/img/crawlers/twitter.svg') },

--- a/client/src/utils/consts.js
+++ b/client/src/utils/consts.js
@@ -1,6 +1,7 @@
 export default {
   env: {
     API_URL: process.env.REACT_APP_API_URL,
+    SOCKET_URL: process.env.SOCKET_API_URL,
   },
   CRAWLERS: [
     { name: 'twitter', label: 'Twitter', logo: require('../assets/img/crawlers/twitter.svg') },

--- a/server/src/config/index.js
+++ b/server/src/config/index.js
@@ -1,3 +1,9 @@
+const redis = {
+  port: process.env.REDIS_PORT || 6379,
+  host: process.env.REDIS_HOSTNAME || 'localhost',
+};
+redis.uri = `redis://${redis.host}:${redis.port}`;
+
 const config = {
   web: {
     port: process.env.PORT || 3001,
@@ -24,9 +30,7 @@ const config = {
     password: process.env.REDDIT_PASSWORD || 'REDDIT_PASSWORD',
     userAgent: 'Mentions/1.0.0',
   },
-  redis: {
-    uri: process.env.REDIS_URI || 'redis://127.0.0.1:6379',
-  },
+  redis,
 };
 
 module.exports = config;

--- a/server/src/config/redis.js
+++ b/server/src/config/redis.js
@@ -3,6 +3,7 @@ const config = require('./index');
 
 module.exports = {
   redis,
+  // Redis client factory
   createRedisClient: () => {
     const client = redis.createClient({
       port: config.redis.port,

--- a/server/src/config/redis.js
+++ b/server/src/config/redis.js
@@ -1,0 +1,19 @@
+const redis = require('redis');
+const config = require('./index');
+
+module.exports = {
+  redis,
+  createRedisClient: () => {
+    const client = redis.createClient({
+      port: config.redis.port,
+      host: config.redis.host,
+    });
+
+    client.on('error', (error) => {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    });
+
+    return client;
+  },
+};

--- a/server/src/loaders/session.js
+++ b/server/src/loaders/session.js
@@ -4,7 +4,9 @@ const session = require('express-session');
 const RedisStore = require('connect-redis')(session);
 const config = require('../config');
 
-const redisClient = redis.createClient(config.redis.uri);
+const { createRedisClient } = require('../config/redis');
+
+const redisClient = createRedisClient();
 const sessionStore = new RedisStore({ client: redisClient });
 
 module.exports = {

--- a/server/src/loaders/socket.js
+++ b/server/src/loaders/socket.js
@@ -79,9 +79,11 @@ function subscribeOrDisconnectSocket(io, socket) {
   };
 
   // Update search term
-  socket.on('search', (data) => {
+  socket.on('🔎', (data) => {
     connections[id].search = data.search;
     connections[id].type = data.type;
+    // Confirm msg reception
+    socket.send('👌');
   });
 
   /**

--- a/server/src/loaders/socket.js
+++ b/server/src/loaders/socket.js
@@ -66,10 +66,16 @@ module.exports = async (server) => {
       socket.disconnect();
       return;
     }
+
+    // Get type and search from query
+    const { type, search } = socket.handshake.query;
+
     const { id } = socket;
     connectedUsers[id] = {
       socket: id,
       user: socket.request.user,
+      type,
+      search,
     };
 
     broadcastCount(io, connectedUsers);

--- a/server/src/loaders/socket.js
+++ b/server/src/loaders/socket.js
@@ -26,18 +26,6 @@ function broadcastConnectionCount(io) {
   io.emit('connected_user', Object.keys(connections).length);
 }
 
-// ########## Test BEGIN ##########
-let interval;
-const emitTest = async (socket) => {
-  // Emitting a new message. Will be consumed by the client
-  const count = await Result.countDocuments();
-  const random = Math.floor(Math.random() * count);
-
-  const res = await Result.findOne().skip(random);
-  socket.emit('mention', res);
-};
-// ########## Test END   ##########
-
 /**
  * Emit `mention` event to socket.io users based on their search criteria OR their terms
  * @param {number} socketId Socket id
@@ -102,19 +90,9 @@ function subscribeOrDisconnectSocket(io, socket) {
 
   broadcastConnectionCount(io);
 
-  // ########## Test BEGIN ##########
-  // if (interval) {
-  //   clearInterval(interval);
-  // }
-  // setInterval(() => emitTest(socket), 3000);
-  // ########## Test END ############
-
   socket.on('disconnect', () => {
     delete connections[id];
     broadcastConnectionCount(io);
-    // ########## Test BEGIN ##########
-    // clearInterval(interval);
-    // ########## Test END ############
 
     mentionSubscriber.unsubscribe();
     mentionSubscriber.quit();

--- a/server/src/loaders/socket.js
+++ b/server/src/loaders/socket.js
@@ -1,7 +1,8 @@
 /* eslint-disable global-require */
 const config = require('../config');
 const { sessionStore } = require('./session');
-const user = require('../models/user');
+const { User } = require('../models/user');
+const { Result } = require('../models/result');
 
 function onAuthorizeSuccess(data, accept) {
   // The accept-callback still allows us to decide whether to
@@ -46,10 +47,14 @@ module.exports = async (server) => {
 
   const connectedUsers = {};
 
-  const emitTest = (socket) => {
-    const response = new Date();
+  const emitTest = async (socket) => {
     // Emitting a new message. Will be consumed by the client
-    socket.emit('test', response);
+
+    const count = await Result.countDocuments();
+    const random = Math.floor(Math.random() * count);
+
+    const res = await Result.findOne().skip(random);
+    socket.emit('mention', res);
   };
 
   // ########## Test ##########
@@ -73,7 +78,7 @@ module.exports = async (server) => {
     if (interval) {
       clearInterval(interval);
     }
-    setInterval(() => emitTest(socket), 1000);
+    setInterval(() => emitTest(socket), 3000);
 
     socket.on('disconnect', () => {
       delete connectedUsers[id];

--- a/server/src/loaders/socket.js
+++ b/server/src/loaders/socket.js
@@ -78,6 +78,12 @@ function subscribeOrDisconnectSocket(io, socket) {
     search,
   };
 
+  // Update search term
+  socket.on('search', (data) => {
+    connections[id].search = data.search;
+    connections[id].type = data.type;
+  });
+
   /**
    * Redis pub/sub subscriber per client
    * Can be optimized by reusing subscriber.

--- a/server/src/models/result.js
+++ b/server/src/models/result.js
@@ -89,6 +89,8 @@ Result.statics.search = async function search(term = '', crawlers, type) {
 
 function trimBodyPlugin(schema, options) {
   schema.post(['find', 'findOne'], (docs) => {
+    if (docs === undefined || docs === null) { return; }
+
     if (Array.isArray(docs)) {
       docs = docs.map((doc) => {
         doc.body = truncateBody(doc.body);

--- a/server/src/models/result.js
+++ b/server/src/models/result.js
@@ -69,7 +69,8 @@ Result.statics.search = async function search(term = '', crawlers, type) {
     ],
     source: { $in: crawlers },
     type,
-  }).sort({ 'meta.sentiment': -1 });
+  }, {}, { limit: 100 })
+    .sort({ 'meta.sentiment': -1 });
 };
 
 const Model = mongoose.model('Result', Result);

--- a/server/src/models/result.js
+++ b/server/src/models/result.js
@@ -16,13 +16,11 @@ const Result = new Schema({
   source: {
     type: String,
     required: true,
-    index: { unique: false },
     trim: true,
   },
   type: {
     type: String,
     required: true,
-    index: { unique: false },
     trim: true,
   },
   author: {
@@ -37,13 +35,11 @@ const Result = new Schema({
   title: {
     type: String,
     required: true,
-    index: { unique: false },
     trim: true,
   },
   body: {
     type: String,
     required: true,
-    index: { unique: false },
     trim: true,
   },
   url: {
@@ -69,6 +65,9 @@ const Result = new Schema({
 }, { timestamps: true });
 
 Result.index({ source: 1, type: 1, url: 1 }, { unique: true });
+Result.index({
+  source: 1, type: 1, title: 'text', body: 'text',
+});
 
 /**
  * Find recent mentions

--- a/server/src/models/result.js
+++ b/server/src/models/result.js
@@ -1,6 +1,15 @@
+/* eslint-disable no-param-reassign */
 const mongoose = require('../config/mongoose');
 
 const { Schema } = mongoose;
+
+function truncateBody(str) {
+  const len = 500;
+  if (str.length <= len) {
+    return str;
+  }
+  return `${str.slice(0, len)}...`;
+}
 
 const Result = new Schema({
   // Crawler Name
@@ -8,15 +17,18 @@ const Result = new Schema({
     type: String,
     required: true,
     index: { unique: false },
+    trim: true,
   },
   type: {
     type: String,
     required: true,
     index: { unique: false },
+    trim: true,
   },
   author: {
     type: String,
     required: false,
+    trim: true,
   },
   date: {
     type: Date,
@@ -26,11 +38,13 @@ const Result = new Schema({
     type: String,
     required: true,
     index: { unique: false },
+    trim: true,
   },
   body: {
     type: String,
     required: true,
     index: { unique: false },
+    trim: true,
   },
   url: {
     type: String,
@@ -72,6 +86,21 @@ Result.statics.search = async function search(term = '', crawlers, type) {
   }, {}, { limit: 100 })
     .sort({ 'meta.sentiment': -1 });
 };
+
+function trimBodyPlugin(schema, options) {
+  schema.post(['find', 'findOne'], (docs) => {
+    if (Array.isArray(docs)) {
+      docs = docs.map((doc) => {
+        doc.body = truncateBody(doc.body);
+        return doc;
+      });
+    } else {
+      docs.body = truncateBody(docs.body);
+    }
+  });
+}
+
+Result.plugin(trimBodyPlugin);
 
 const Model = mongoose.model('Result', Result);
 

--- a/server/src/models/result.js
+++ b/server/src/models/result.js
@@ -87,6 +87,9 @@ Result.statics.search = async function search(term = '', crawlers, type) {
     .sort({ 'meta.sentiment': -1 });
 };
 
+/**
+ * Plugin to trim body text on read
+ */
 function trimBodyPlugin(schema, options) {
   schema.post(['find', 'findOne'], (docs) => {
     if (docs === undefined || docs === null) { return; }
@@ -102,6 +105,7 @@ function trimBodyPlugin(schema, options) {
   });
 }
 
+// Register our plugin
 Result.plugin(trimBodyPlugin);
 
 const Model = mongoose.model('Result', Result);

--- a/server/src/queues/search.js
+++ b/server/src/queues/search.js
@@ -1,0 +1,4 @@
+const Queue = require('bull');
+const config = require('../config');
+
+module.exports = new Queue('search', config.redis.uri);

--- a/server/src/services/crawler/reddit/index.js
+++ b/server/src/services/crawler/reddit/index.js
@@ -31,10 +31,10 @@ async function search(term, type) {
   const query = {
     q: term,
     limit: 50,
-    sort: type,
+    sort: type === 'popular' ? 'hot' : 'new',
   };
   const posts = await reddit.get('/search', query);
-  return posts.data.children.map((result) => convert(query.result_type, result));
+  return posts.data.children.map((result) => convert(type, result));
 }
 
 /**
@@ -42,6 +42,6 @@ async function search(term, type) {
  */
 module.exports = {
   name: 'reddit',
-  findPopular: (term) => search(term, 'hot'),
-  findRecent: (term) => search(term, 'new'),
+  findPopular: (term) => search(term, 'popular'),
+  findRecent: (term) => search(term, 'recent'),
 };

--- a/server/src/services/queue.js
+++ b/server/src/services/queue.js
@@ -1,6 +1,9 @@
 const Queue = require('bull');
 
 const { User } = require('../models');
+
+const searchQueue = require('../queues/search');
+
 const searchProcessor = require('./processors/search');
 const config = require('../config');
 
@@ -11,7 +14,6 @@ const config = require('../config');
  */
 function addToSearchQueue(search, priority = 9) {
   try {
-    const searchQueue = new Queue('search', config.redis.uri);
     searchQueue.add({ search }, { priority });
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -24,8 +26,6 @@ function addToSearchQueue(search, priority = 9) {
  */
 function startSearchQueueProcessing() {
   // Start queue processor
-  const searchQueue = new Queue('search', config.redis.uri);
-  // (could also have been done through another queue)
   searchQueue.on('completed', searchProcessor.saveSearchResult);
   searchQueue.process(searchProcessor.processSearchJob);
 }


### PR DESCRIPTION
### What it does

- [x] once a new result from a job happens and it matches a users company terms, emit an event with the new results 
   - [x] look at the ids of the connected users, do any of the terms match for the documents that have been matched 
   - [x] a map of user-id with socket-ids (may have this info already with passport-socket)
- [x] front-end will open socket on the mentions search page and would listen for any new results from the broadcast message (taking in account the current search) 
- [x] close the connection upon exiting the search page 

#### Technical

- Socket.io added to front
- Use of redis pub/sub to broadcast new mentions to all service instances
- Use of local in-memory dictionary to keep track of socket/search relation for connections on current service instance
- `cpr` added to front as dev dependency to simplify copy of build assets to backend

### What to look for

- Naming issue
- Missing comment
- Best practices
- Commit 30fc9dc8665361a92fd5c98a06a83edb99751433 if you want sample code to enable fake events at interval

### What to avoid

- Unit tests not implemented